### PR TITLE
backend: embed front-end files into server binary, fixup makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 site/scripts/*.js
 site/scripts/*.js.map
 site/css/external/*
-Database.json
+[Dd]atabase.json
 build/
+mealbot.service
+.vscode
+.viminfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
-ARG serverBinary="build/mealbot"
-ARG siteRoot="./site"
 FROM alpine:latest
 
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
-ADD build/ /opt/mealbot/
+ADD build/mealbot /usr/bin/mealbot
 
 EXPOSE 80
-WORKDIR /opt/mealbot/
-ENV MEALBOT_DB="/mnt/Database.json"
-ENTRYPOINT [ "/opt/mealbot/mealbot" ]
+ENTRYPOINT [ "/usr/bin/mealbot" ]

--- a/Makefile
+++ b/Makefile
@@ -2,21 +2,29 @@ all: depends release
 
 
 depends:
-	@/usr/bin/tsc --version >/dev/null || (echo "missing typescript compiler"; exit 1)
-	@/usr/bin/go version >/dev/null || (echo "missing golang"; exit 1)
+	@$$(which tsc) --version >/dev/null || (echo "missing typescript compiler"; exit 1)
+	@$$(which go) version >/dev/null || (echo "missing golang"; exit 1)
+	@$$(which curl) --version >/dev/null || (echo "missing curl"; exit 1)
+	@$$(which 7z) >/dev/null || (echo "missing p7zip"; exit 1)
+	@ls -l ./site/css/external/fontawesome6 >/dev/null || (curl -L https://use.fontawesome.com/releases/v6.2.1/fontawesome-free-6.2.1-web.zip -o site/css/external/fontawesome6.zip \
+						&& 7z x site/css/external/fontawesome6.zip -o"site/css/external/fontawesome6" \
+						&& mv site/css/external/fontawesome6/fontawesome-free-6.2.1-web/* site/css/external/fontawesome6/ \
+						&& rmdir  site/css/external/fontawesome6/fontawesome-free-6.2.1-web/)
+	@rm -f site/css/external/fontawesome6.zip
 
 release: depends
-	/usr/bin/tsc
-	mkdir -p build/
-	find ./site -regextype egrep -iregex "^(.*/external/.*|.*\.(html|css|js))\$$" -exec install -D -m 600 "{}" "build/{}" \;
-	/usr/bin/go build -o "build/mealbot" -v ./cmd
+	@$$(which tsc)
+	@$$(which go) build -o "build/mealbot" -v ./cmd
 
 debug: depends
-	/usr/bin/tsc
-	/usr/bin/go run ./cmd
+	@$$(which tsc)
+	@$$(which go) run ./cmd
 
 container: release
-	docker build . -t bowerscd/special-tribble:latest
+	@$$(which docker) build . -t bowerscd/special-tribble:latest
+
+pkg:
+
 
 clean:
-	rm -rf build
+	@rm -rf build

--- a/cmd/mb_serve.go
+++ b/cmd/mb_serve.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/bowerscd/mealbot/internal"
+	"github.com/bowerscd/mealbot/site"
 )
 
 const dbgHeader string = "x-mealbot-bad-request"
@@ -146,7 +147,7 @@ func main() {
 
 	server := http.NewServeMux()
 	server.Handle("/api/", ApiHandler())
-	server.Handle("/", http.FileServer(http.Dir("site/")))
+	server.Handle("/", http.FileServer(http.FS(site.EmbeddedSite)))
 
 	err := internal.InitDB(db)
 	if err != nil {

--- a/site/site.go
+++ b/site/site.go
@@ -1,0 +1,7 @@
+package site
+
+import "embed"
+
+//go:embed index.html
+//go:embed css/* scripts/*.js templates/*
+var EmbeddedSite embed.FS


### PR DESCRIPTION
Embed the front-end files for the builds, divorcing some potential issues with a not-updated version of the site. Make the makefile download fontawesome6 (our main dependency) if it does not exist.

Signed-off-by: Deven Bowers <bowerscd.source@gmail.com>