### PR TITLE
dockerfile: change base to archlinux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM alpine:latest
+FROM archlinux:latest
 
-RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+RUN pacman-key --init
+RUN pacman -Sy archlinux-keyring --noconfirm
+RUN pacman -Syu --noconfirm
 ADD build/mealbot /usr/bin/mealbot
 
 EXPOSE 80


### PR DESCRIPTION
The base docker image was alpine, which had some hacks to work around muslc, as well as stale glibc versions. Switch it to archlinux as that tends to be what my dev machine is.